### PR TITLE
fix links in the main page header

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,14 +23,14 @@
   <main>
     <header class="header">
       <div class="header_logo">
-        <a href="/">
-          <img src="/images/logo_en.svg" alt="Logo the Netherlands"></a>
+        <a href="./index.html">
+          <img src="./images/logo_en.svg" alt="Logo the Netherlands"></a>
       </div>
       <ul class="header_navigation">
-        <li><a href="/pages/amsterdam.html">Amsterdam</a></li>
-        <li><a href="/pages/rotterdam.html">Rotterdam</a></li>
-        <li><a href="/pages/the_hague.html">The Hague</a></li>
-        <li><a href="/pages/utrecht.html">Utrecht</a></li>
+        <li><a href="./pages/amsterdam.html">Amsterdam</a></li>
+        <li><a href="./pages/rotterdam.html">Rotterdam</a></li>
+        <li><a href="./pages/the_hague.html">The Hague</a></li>
+        <li><a href="./pages/utrecht.html">Utrecht</a></li>
       </ul>
       <div class="header_button">
         <a href="https://www.holland.com/global/tourism.htm" target="_blank">


### PR DESCRIPTION
Previous edits to links in the home page header broke their functionality. These changes have been reversed. The Utrecht page is not affected, links are correct there.